### PR TITLE
Add Timekeep

### DIFF
--- a/fusion3.mk
+++ b/fusion3.mk
@@ -201,6 +201,10 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     thermanager
 
+#keep track of time & date since the RTC driver on Qualcomm chipset is read-only.
+    timekeep \
+    TimeKeep
+
 # WIFI MAC update
 PRODUCT_PACKAGES += \
     mac-update

--- a/rootdir/init.qcom.rc
+++ b/rootdir/init.qcom.rc
@@ -431,3 +431,9 @@ service taimport /system/bin/taimport
     user root
     disabled
     oneshot
+
+service timekeep /system/bin/timekeep restore
+   class late_start
+   user root
+   group root
+   oneshot

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -53,6 +53,7 @@
 /system/bin/ta_qmi_client           u:object_r:ta_qmi_client_exec:s0
 /system/bin/tad_static              u:object_r:tad_exec:s0
 /system/bin/taimport                u:object_r:taimport_exec:s0
+/system/bin/timekeep                u:object_r:timekeep_exec:s0
 /system/bin/thermanager             u:object_r:thermanager_exec:s0
 /system/bin/updatemiscta            u:object_r:updatemiscta_exec:s0
 

--- a/sepolicy/property.te
+++ b/sepolicy/property.te
@@ -1,1 +1,2 @@
+type timekeep_prop, property_type;
 type updatemiscta_prop, property_type;

--- a/sepolicy/property_contexts
+++ b/sepolicy/property_contexts
@@ -1,1 +1,2 @@
+persist.sys.timeadjust         u:object_r:timekeep_prop:s0
 persist.tareset.notfirstboot          u:object_r:updatemiscta_prop:s0

--- a/sepolicy/service.te
+++ b/sepolicy/service.te
@@ -1,0 +1,1 @@
+type timekeep_service,           service_manager_type;

--- a/sepolicy/service_contexts
+++ b/sepolicy/service_contexts
@@ -1,0 +1,1 @@
+com.sony.timekeep        u:object_r:timekeep_service:s0

--- a/sepolicy/system_app.te
+++ b/sepolicy/system_app.te
@@ -1,1 +1,2 @@
+allow system_app timekeep_prop:property_service set;
 allow system_app rootfs:file { rx_file_perms };

--- a/sepolicy/timekeep.te
+++ b/sepolicy/timekeep.te
@@ -1,0 +1,7 @@
+type timekeep, domain;
+type timekeep_exec, exec_type, file_type;
+
+# Started by init
+init_daemon_domain(timekeep)
+
+allow timekeep self:capability { sys_time };


### PR DESCRIPTION
This function is required to have time and date work properly.

Add this to the manifest:

<remote  name="sony" fetch="git://github.com/sonyxperiadev/" />
<project path="vendor/sony/system/timekeep" name="timekeep" groups="device" remote="sony" revision="master" />
